### PR TITLE
Update dablooms.c

### DIFF
--- a/src/dablooms.c
+++ b/src/dablooms.c
@@ -103,6 +103,7 @@ bitmap_t *new_bitmap(int fd, size_t bytes)
     bitmap->array = NULL;
     
     if ((bitmap = bitmap_resize(bitmap, 0, bytes)) == NULL) {
+        bitmap_free(bitmap);
         return NULL;
     }
     


### PR DESCRIPTION
Infer says it can't be found after line 105. But when we rerun infer with this patch, it still complains, unless we put it before line 105. But it doesn't complain if we move (for example) the other patches in dablooms later. It's weird.